### PR TITLE
Update error message handling

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -360,7 +360,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                 function(err, accessToken) {
                   if (err) {
                     return err.code === 'LOGIN_FAILED' ?
-                      done(null, false, {message: g.f('Failed to create token.')}) :
+                      done(null, false, {message: g.f('Email or password was incorrect.')}) :
                       done(err);
                   }
                   if (accessToken && user.emailVerified) {
@@ -547,6 +547,9 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
     // The default callback
     passport.authenticate(name, _.defaults({session: session},
       options.authOptions), function(err, user, info) {
+      if (err && err.message && options.failureQueryString) {
+        return res.redirect(appendErrorToQueryString(failureRedirect, err));
+      }
       if (err) {
         return next(err);
       }
@@ -682,7 +685,8 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
   function appendErrorToQueryString(url, err) {
     var hasQueryString = (url.indexOf('?') !== -1);
     var separator = (hasQueryString) ? '&' : '?';
-    var fieldValuePair = 'error=' + encodeURIComponent(err);
+    const message = err && err.message ? err.message : err;
+    var fieldValuePair = 'error=' + encodeURIComponent(message);
     var queryString = url + separator + fieldValuePair;
     return queryString;
   }


### PR DESCRIPTION
Update error messages, and make sure that the message makes its way to the end user and they don't end up on a dead page.

An "email has not been verified" error will return an `err.messsage`, which we don't want to `next(err)` because that will send the user to an unhelpful 500 page where they cannot do anything.

`appendErrorToQueryString` will not handle the `{message: g.f('Email or password was incorrect.')}` object, only an actual Error. The current structure and `g.f` (globallization) is still wanted and doesn't need to be changed.